### PR TITLE
[BE][DB] Create migration/seeder scripts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,9 @@
     "start": "node .",
     "test": "echo \"Error: no test specified\" && exit 1",
     "db:migrate": "npx ts-node ./node_modules/sequelize-cli/lib/sequelize db:migrate",
-    "db:migrate:undo": "npx ts-node ./node_modules/sequelize-cli/lib/sequelize db:migrate:undo:all"
+    "db:migrate:undo": "npx ts-node ./node_modules/sequelize-cli/lib/sequelize db:migrate:undo:all",
+    "db:seed": "npx ts-node ./node_modules/sequelize-cli/lib/sequelize db:seed:all",
+    "db:seed:undo": "npx ts-node ./node_modules/sequelize-cli/lib/sequelize db:seed:undo"
   },
   "author": "",
   "license": "MIT",

--- a/backend/src/migrations/20210829130448-create-extension-uuid.ts
+++ b/backend/src/migrations/20210829130448-create-extension-uuid.ts
@@ -1,0 +1,10 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";');
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query('DROP EXTENSION IF EXISTS "uuid-ossp";');
+  }
+};

--- a/backend/src/migrations/20210829131820-create-auth-permissions.ts
+++ b/backend/src/migrations/20210829131820-create-auth-permissions.ts
@@ -1,0 +1,26 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE auth_permission
+    (
+        id         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        name       VARCHAR NOT NULL, -- permissions name
+        code_name  VARCHAR NOT NULL, -- permission code
+        created_at TIMESTAMP        DEFAULT current_timestamp,
+        updated_at TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+
+    await queryInterface.bulkInsert("auth_permission", [
+      { name: "CREATE_USER", code_name: 200 },
+      { name: "READ_USER", code_name: 200 },
+      { name: "UPDATE_USER", code_name: 200 },
+      { name: "DELETE_USER", code_name: 200 },
+    ]);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('auth_permission');
+  }
+};

--- a/backend/src/migrations/20210829131912-create-auth-group.ts
+++ b/backend/src/migrations/20210829131912-create-auth-group.ts
@@ -1,0 +1,23 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE auth_group
+    (
+        id         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        name       VARCHAR NOT NULL,
+        created_at TIMESTAMP        DEFAULT current_timestamp,
+        updated_at TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+
+    await queryInterface.bulkInsert("auth_group", [
+      { name: "admin_user" },
+      { name: "normal_user" },
+    ]);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('auth_group');
+  }
+};

--- a/backend/src/migrations/20210829132347-create-application-status.ts
+++ b/backend/src/migrations/20210829132347-create-application-status.ts
@@ -1,0 +1,27 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE application_status
+    (
+        id         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        status     VARCHAR UNIQUE NOT NULL,
+        created_at TIMESTAMP        DEFAULT current_timestamp,
+        updated_at TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+
+    await queryInterface.bulkInsert("application_status", [
+      { status: "Pending" },
+      { status: "Rejected" },
+      { status: "Withdrew" },
+      { status: "Shortlisted" },
+      { status: "Scheduled" },
+      { status: "Completed" },
+    ]);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('application_status');
+  }
+};

--- a/backend/src/migrations/20210829132705-create-application-type.ts
+++ b/backend/src/migrations/20210829132705-create-application-type.ts
@@ -1,0 +1,23 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE application_type
+    (
+        id         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        type       VARCHAR UNIQUE NOT NULL,
+        created_at TIMESTAMP        DEFAULT current_timestamp,
+        updated_at TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+
+    await queryInterface.bulkInsert("application_type", [
+      { type: "Adoption" },
+      { type: "Foster" }
+    ]);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('application_type');
+  }
+};

--- a/backend/src/migrations/20210829132854-create-adoption-status.ts
+++ b/backend/src/migrations/20210829132854-create-adoption-status.ts
@@ -1,0 +1,24 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE adoption_status
+    (
+        id         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        status     VARCHAR UNIQUE NOT NULL,
+        created_at TIMESTAMP        DEFAULT current_timestamp,
+        updated_at TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+
+    await queryInterface.bulkInsert("adoption_status", [
+      { status: "Ongoing" },
+      { status: "Adopted" },
+      { status: "Archived" }
+    ]);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('adoption_status');
+  }
+};

--- a/backend/src/migrations/20210829133009-create-species.ts
+++ b/backend/src/migrations/20210829133009-create-species.ts
@@ -1,0 +1,24 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE species
+    (
+        id         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        name       VARCHAR UNIQUE NOT NULL,
+        created_at TIMESTAMP        DEFAULT current_timestamp,
+        updated_at TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+
+    await queryInterface.bulkInsert("species", [
+      { name: "Cat" },
+      { name: "Dog" },
+      { name: "Others" }
+    ]);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('species');
+  }
+};

--- a/backend/src/migrations/20210829134025-create-auth-user.ts
+++ b/backend/src/migrations/20210829134025-create-auth-user.ts
@@ -1,0 +1,23 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE auth_user
+    (
+        id         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        username   VARCHAR NOT NULL UNIQUE,
+        email      VARCHAR NOT NULL UNIQUE,
+        password   VARCHAR NOT NULL,
+        is_staff   BOOLEAN NOT NULL,
+        is_active  BOOLEAN NOT NULL,
+        is_admin   BOOLEAN NOT NULL,
+        created_at TIMESTAMP        DEFAULT current_timestamp,
+        updated_at TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('auth_user');
+  }
+};

--- a/backend/src/migrations/20210829134256-create-auth-user-permission.ts
+++ b/backend/src/migrations/20210829134256-create-auth-user-permission.ts
@@ -1,0 +1,19 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE auth_user_permission
+    (
+        id                 UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        auth_user_id       UUID REFERENCES auth_user (id),
+        auth_permission_id UUID REFERENCES auth_permission (id),
+        created_at         TIMESTAMP        DEFAULT current_timestamp,
+        updated_at         TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('auth_user_permission');
+  }
+};

--- a/backend/src/migrations/20210829135212-create-auth-group-permission.ts
+++ b/backend/src/migrations/20210829135212-create-auth-group-permission.ts
@@ -1,0 +1,19 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE auth_group_permission
+    (
+        PRIMARY KEY (auth_group_id, auth_permission_id),
+        auth_group_id      UUID REFERENCES auth_group (id),
+        auth_permission_id UUID REFERENCES auth_permission (id),
+        created_at         TIMESTAMP DEFAULT current_timestamp,
+        updated_at         TIMESTAMP DEFAULT current_timestamp
+    );
+    `);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('auth_group_permission');
+  }
+};

--- a/backend/src/migrations/20210829135258-create-auth-user-group-permission.ts
+++ b/backend/src/migrations/20210829135258-create-auth-user-group-permission.ts
@@ -1,0 +1,19 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE auth_user_group_permission
+    (
+        id            UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        auth_user_id  UUID REFERENCES auth_user (id),
+        auth_group_id UUID REFERENCES auth_group (id),
+        created_at    TIMESTAMP        DEFAULT current_timestamp,
+        updated_at    TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('auth_user_group_permission');
+  }
+};

--- a/backend/src/migrations/20210829135336-create-user-profile.ts
+++ b/backend/src/migrations/20210829135336-create-user-profile.ts
@@ -1,0 +1,29 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE user_profile
+    (
+        id           UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        auth_user_id UUID REFERENCES auth_user (id),
+        email        VARCHAR NOT NULL UNIQUE,
+        phone_no     VARCHAR NOT NULL,
+        nric         VARCHAR UNIQUE, -- Putting it as optional first
+        first_name   VARCHAR NOT NULL,
+        last_name    VARCHAR NOT NULL,
+        dob          DATE    NOT NULL,
+        gender       CHAR(1) NOT NULL
+            CONSTRAINT gender_vals CHECK (gender IN ('F', 'M')),
+        occupation   VARCHAR,
+        address      VARCHAR NOT NULL,
+        postal_code  VARCHAR NOT NULL,
+        created_at   TIMESTAMP        DEFAULT current_timestamp,
+        updated_at   TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('user_profile');
+  }
+};

--- a/backend/src/migrations/20210829135406-create-shelter.ts
+++ b/backend/src/migrations/20210829135406-create-shelter.ts
@@ -1,0 +1,22 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE shelter
+    (
+        id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        name            VARCHAR NOT NULL,
+        address         VARCHAR NOT NULL,
+        country         VARCHAR NOT NULL,
+        contact         VARCHAR NOT NULL,
+        registration_no VARCHAR,
+        created_at      TIMESTAMP        DEFAULT current_timestamp,
+        updated_at      TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('shelter');
+  }
+};

--- a/backend/src/migrations/20210829135513-create-animal.ts
+++ b/backend/src/migrations/20210829135513-create-animal.ts
@@ -1,0 +1,37 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE animal
+    (
+        id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        shelter_id      UUID REFERENCES shelter (id),
+        adoption_status VARCHAR REFERENCES adoption_status (status),
+        species         VARCHAR REFERENCES species (name),
+        name            VARCHAR NOT NULL,
+        description     VARCHAR NOT NULL DEFAULT '',
+        health_issues   VARCHAR NOT NULL DEFAULT '',
+        gender          CHAR(1) NOT NULL
+            CONSTRAINT gender_vals CHECK (gender IN ('F', 'M')),
+        age_months      INTEGER,
+        size_cm         INTEGER,
+        breed           VARCHAR,
+        color           VARCHAR NOT NULL,
+        weight_kg       NUMERIC,
+        fur_length      VARCHAR,
+        vaccinated      BOOLEAN,
+        dewormed        BOOLEAN,
+        sterilized      BOOLEAN,
+        adoption_fee    NUMERIC,
+        intake_date     DATE    NOT NULL,
+    
+        created_at      TIMESTAMP        DEFAULT current_timestamp,
+        updated_at      TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('animal');
+  }
+};

--- a/backend/src/migrations/20210829135520-create-animal-image.ts
+++ b/backend/src/migrations/20210829135520-create-animal-image.ts
@@ -1,0 +1,19 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE animal_image
+    (
+        animal_id     UUID REFERENCES animal (id) ON DELETE CASCADE,
+        photo_url     VARCHAR,
+        thumbnail_url VARCHAR,
+        created_at    TIMESTAMP DEFAULT current_timestamp,
+        updated_at    TIMESTAMP DEFAULT current_timestamp
+    );
+    `);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('animal_image');
+  }
+};

--- a/backend/src/migrations/20210829135554-create-user-animal.ts
+++ b/backend/src/migrations/20210829135554-create-user-animal.ts
@@ -1,0 +1,19 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE user_animal
+    (
+        id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        user_profile_id UUID REFERENCES user_profile (id),
+        animal_id       UUID REFERENCES animal (id),
+        created_at      TIMESTAMP        DEFAULT current_timestamp,
+        updated_at      TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('user_animal');
+  }
+};

--- a/backend/src/migrations/20210829135633-create-adopted-animal-update.ts
+++ b/backend/src/migrations/20210829135633-create-adopted-animal-update.ts
@@ -1,0 +1,22 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE adopted_animal_update
+    (
+        id             UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        user_animal_id UUID REFERENCES user_animal (id),
+        title          VARCHAR NOT NULL,
+        due_date       DATE    NOT NULL,
+        user_update    VARCHAR,
+        published_date DATE,
+        created_at     TIMESTAMP        DEFAULT current_timestamp,
+        updated_at     TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('adopted_animal_update');
+  }
+};

--- a/backend/src/migrations/20210829135719-create-user-animal-application.ts
+++ b/backend/src/migrations/20210829135719-create-user-animal-application.ts
@@ -1,0 +1,24 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`
+    CREATE TABLE user_animal_application
+    (
+        id                  UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        user_profile_id     UUID REFERENCES user_profile (id),
+        animal_id           UUID REFERENCES animal (id),
+        application_type    VARCHAR REFERENCES application_type (type),      -- adoption or fostering
+        application_status  varchar REFERENCES application_status (status), -- pending, etc
+        reason_for_adoption VARCHAR,
+        rejection_reason    VARCHAR,
+        adoption_fee        NUMERIC NOT NULL,
+        created_at          TIMESTAMP        DEFAULT current_timestamp,
+        updated_at          TIMESTAMP        DEFAULT current_timestamp
+    );
+    `);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.dropTable('user_animal_application');
+  }
+};

--- a/backend/src/seeders/20210829152403-seed-shelter-example.ts
+++ b/backend/src/seeders/20210829152403-seed-shelter-example.ts
@@ -1,0 +1,82 @@
+import { QueryInterface } from "sequelize";
+
+const SHELTER_ID = "e9c4fb2c-e5bb-4d14-be23-6c264130be88";
+const ANIMAL_ID_CAT_1 = "377fee7f-37cb-4aaf-a805-b41eaa6bf590";
+const ANIMAL_ID_DOG_1 = "de810095-533e-4be9-80eb-a85baeac835d";
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.bulkInsert("shelter", [
+      {
+        id: SHELTER_ID,
+        name: "SPCA",
+        address: "50 Sungei Tengah Rd, Singapore 699012",
+        country: "Singapore",
+        contact: "6287 5355"
+      }
+    ]);
+
+    await queryInterface.bulkInsert("animal", [
+      {
+        id: ANIMAL_ID_CAT_1,
+        shelter_id: SHELTER_ID,
+        adoption_status: "Ongoing",
+        adoption_fee: 50,
+        species: "Cat",
+        name: "Tom",
+        description: "Tom is a friendly cat with a little fiesty temper",
+        health_issues: "A little fat",
+        gender: "M",
+        age_months: 13,
+        size_cm: 35,
+        breed: "Local",
+        color: "Black",
+        weight_kg: 2.5,
+        fur_length: "long hair",
+        vaccinated: false,
+        dewormed: false,
+        sterilized: false,
+        intake_date: "2021-08-27"
+      },
+      {
+        id: ANIMAL_ID_DOG_1,
+        shelter_id: SHELTER_ID,
+        adoption_status: "Ongoing",
+        adoption_fee: 50,
+        species: "Dog",
+        name: "Toto",
+        description: "",
+        health_issues: "",
+        gender: "F",
+        age_months: 36,
+        size_cm: 38,
+        breed: "Local",
+        color: "Brown",
+        weight_kg: 5.2,
+        fur_length: "long hair",
+        vaccinated: false,
+        dewormed: false,
+        sterilized: false,
+        intake_date: "2021-08-29"
+      }
+    ]);
+
+    await queryInterface.bulkInsert("animal_image", [
+      {
+        animal_id: ANIMAL_ID_CAT_1,
+        photo_url: "https://picsum.photos/800",
+        thumbnail_url: "https://picsum.photos/200"
+      },
+      {
+        animal_id: ANIMAL_ID_DOG_1,
+        photo_url: "https://images.unsplash.com/photo-1599446220101-d3e0c4b74a53?w=634",
+        thumbnail_url: "https://images.unsplash.com/photo-1599446220101-d3e0c4b74a53?w=300"
+      }
+    ]);
+  },
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.bulkDelete("animal_image", { animal_id: [ANIMAL_ID_CAT_1, ANIMAL_ID_DOG_1] });
+    await queryInterface.bulkDelete("animal", { id: [ANIMAL_ID_CAT_1, ANIMAL_ID_DOG_1] });
+    await queryInterface.bulkDelete("shelter", { id: SHELTER_ID });
+  }
+};


### PR DESCRIPTION
### Description
Quick conversion of the schema from commit [839219e6ec4d044678909feb917b153ba83d9c27](https://github.com/bettersg/PawScore/commit/839219e6ec4d044678909feb917b153ba83d9c27) to sequelize migrations. This should allow devs to incrementally update the database schema as the models evolve in the future. Also added a sample seeder that can be used in the upcoming api to fetch animals.

### Changes 
- Created migration scripts for both data tables and tables representing constant values in `backend/src/migrations`
- Created a seeder example for seeding a shelter with two animals in `backend/src/seeders`
- Added npm scripts to run or revert migrations/seeders