### PR TITLE
[FE] [Modal] Added alert modal

### DIFF
--- a/frontend/components/saveModal.tsx
+++ b/frontend/components/saveModal.tsx
@@ -1,8 +1,9 @@
-import { Modal, Button } from "antd";
+import { Modal, Button, message } from "antd";
 import { ExclamationCircleOutlined } from "@ant-design/icons";
 
 const SaveModal = (props) => {
-	const { confirm } = Modal;
+  const { confirm } = Modal;
+  const key = 'updatable';
 
 	const onClickCancel = () => {
 		confirm({
@@ -28,13 +29,20 @@ const SaveModal = (props) => {
 			okText: "Yes",
 			cancelText: "No",
 			onOk() {
-				console.log("OK");
+				onSaveConfirm();
 			},
 			onCancel() {
 				console.log("Cancel");
 			}
 		});
-	};
+  };
+  
+  const onSaveConfirm = () => {
+    message.loading({ content: 'Saving changes...', key });
+    setTimeout(() => {
+      message.success({ content: 'Changes saved successfully', key, duration: 2 });
+    }, 1500);
+  };
 
 	return (
 		<div>

--- a/frontend/components/saveModal.tsx
+++ b/frontend/components/saveModal.tsx
@@ -1,0 +1,52 @@
+import { Modal, Button } from "antd";
+import { ExclamationCircleOutlined } from "@ant-design/icons";
+
+const SaveModal = (props) => {
+	const { confirm } = Modal;
+
+	const onClickCancel = () => {
+		confirm({
+			title: "Discard changes?",
+			icon: <ExclamationCircleOutlined />,
+			content: "Any unsaved changes will be discarded.",
+			okText: "Yes",
+			okType: "danger",
+			cancelText: "No",
+			onOk() {
+				console.log("OK");
+			},
+			onCancel() {
+				console.log("Cancel");
+			}
+		});
+	};
+
+	const onClickSave = () => {
+		confirm({
+			title: "Save changes?",
+			icon: <ExclamationCircleOutlined style={{ color: "#1890FF" }} />,
+			okText: "Yes",
+			cancelText: "No",
+			onOk() {
+				console.log("OK");
+			},
+			onCancel() {
+				console.log("Cancel");
+			}
+		});
+	};
+
+	return (
+		<div>
+      {props.type === "primary" ? (
+        <Button onClick={onClickSave} type="primary">
+					Save
+				</Button>
+      ) : (
+          <Button onClick={onClickCancel}>Cancel</Button>
+			)}
+		</div>
+	);
+};
+
+export default SaveModal;


### PR DESCRIPTION
Component `<SaveModal />` takes a prop `type`, with boolean values for the property "primary". `type===primary` creates a button that onClick opens the "Save changes?" modal.

![Screenshot 2021-09-08 at 20 00 58](https://user-images.githubusercontent.com/32130807/132577444-83fe358d-f1ad-47bd-a43e-e311094e9b1c.png)

![Screenshot 2021-09-08 at 20 01 03](https://user-images.githubusercontent.com/32130807/132577167-6efdae51-ccd5-4f14-9fd5-fb9df5c58ddc.png)

Further, on clicking "yes" on the save modal a toast is returned that changes have been saved successfully.

![image](https://user-images.githubusercontent.com/32130807/132579827-2ef1615f-b116-44ac-8a76-a8df8126d26d.png)