### PR TITLE
[FE] Enable strict type checking

### DIFF
--- a/frontend/components/saveModal.tsx
+++ b/frontend/components/saveModal.tsx
@@ -1,9 +1,13 @@
 import { Modal, Button, message } from "antd";
 import { ExclamationCircleOutlined } from "@ant-design/icons";
 
-const SaveModal = (props) => {
-  const { confirm } = Modal;
-  const key = 'updatable';
+type Props = {
+	type: "primary" | string;
+};
+
+const SaveModal = (props: Props) => {
+	const { confirm } = Modal;
+	const key = "updatable";
 
 	const onClickCancel = () => {
 		confirm({
@@ -35,23 +39,27 @@ const SaveModal = (props) => {
 				console.log("Cancel");
 			}
 		});
-  };
-  
-  const onSaveConfirm = () => {
-    message.loading({ content: 'Saving changes...', key });
-    setTimeout(() => {
-      message.success({ content: 'Changes saved successfully', key, duration: 2 });
-    }, 1500);
-  };
+	};
+
+	const onSaveConfirm = () => {
+		message.loading({ content: "Saving changes...", key });
+		setTimeout(() => {
+			message.success({
+				content: "Changes saved successfully",
+				key,
+				duration: 2
+			});
+		}, 1500);
+	};
 
 	return (
 		<div>
-      {props.type === "primary" ? (
-        <Button onClick={onClickSave} type="primary">
+			{props.type === "primary" ? (
+				<Button onClick={onClickSave} type="primary">
 					Save
 				</Button>
-      ) : (
-          <Button onClick={onClickCancel}>Cancel</Button>
+			) : (
+				<Button onClick={onClickCancel}>Cancel</Button>
 			)}
 		</div>
 	);

--- a/frontend/layouts/shelter/ShelterLayout/HeaderContent.tsx
+++ b/frontend/layouts/shelter/ShelterLayout/HeaderContent.tsx
@@ -1,4 +1,5 @@
 import { Menu } from "antd";
+import { MenuClickEventHandler } from "rc-menu/lib/interface";
 import Image from "next/image";
 import styles from "./ShelterLayout.module.css";
 
@@ -6,7 +7,15 @@ const logo = "/logo.png";
 
 const { headerLogo, menuLogo, headerMenu, headerSubMenu } = styles;
 
-const HeaderContent = ({ handleEditProfileClick, handleSignOutClick }) => {
+type Props = {
+	handleEditProfileClick: MenuClickEventHandler;
+	handleSignOutClick: MenuClickEventHandler;
+};
+
+const HeaderContent = ({
+	handleEditProfileClick,
+	handleSignOutClick
+}: Props) => {
 	const accountAvatar = (
 		<Image
 			src="https://via.placeholder.com/32"

--- a/frontend/layouts/shelter/ShelterLayout/index.tsx
+++ b/frontend/layouts/shelter/ShelterLayout/index.tsx
@@ -6,7 +6,11 @@ import styles from "./ShelterLayout.module.css";
 const { Header, Content } = Layout;
 const { header, sideMenu } = styles;
 
-const ShelterLayout = ({ children }) => {
+type Props = {
+	children: JSX.Element;
+};
+
+const ShelterLayout = ({ children }: Props) => {
 	// const isLoggedIn = true;
 
 	const handleEditProfileClick = () => {

--- a/frontend/layouts/shelter/ShelterLoginLayout/index.tsx
+++ b/frontend/layouts/shelter/ShelterLoginLayout/index.tsx
@@ -4,7 +4,11 @@ import styles from "./ShelterLoginLayout.module.css";
 const { Header, Content, Footer } = Layout;
 const logo = "/logo.png";
 
-const ShelterHomeLayout = ({ children }) => {
+type ShelterHomeLayoutProps = {
+	children: JSX.Element;
+};
+
+const ShelterHomeLayout = ({ children }: ShelterHomeLayoutProps) => {
 	return (
 		<Layout>
 			<Header className={styles.header}>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
 			"devDependencies": {
 				"@types/node": "^16.7.1",
 				"@types/react": "^17.0.19",
+				"@types/styled-components": "^5.1.14",
 				"eslint": "7.32.0",
 				"eslint-config-next": "11.1.0",
 				"prettier": "2.3.2",
@@ -861,6 +862,16 @@
 			"integrity": "sha512-Myxw//kzromB9yWgS8qYGuGVf91oBUUJpNvy5eM50sqvmKLbKjwLxohJnkWGTeeI9v9IBMtPLxz5Gc60FIfvCA==",
 			"dev": true
 		},
+		"node_modules/@types/hoist-non-react-statics": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+			"integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+			"dev": true,
+			"dependencies": {
+				"@types/react": "*",
+				"hoist-non-react-statics": "^3.3.0"
+			}
+		},
 		"node_modules/@types/node": {
 			"version": "16.7.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
@@ -888,6 +899,17 @@
 			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
 			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
 			"dev": true
+		},
+		"node_modules/@types/styled-components": {
+			"version": "5.1.14",
+			"resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.14.tgz",
+			"integrity": "sha512-d6P1/tyNytqKwam3cQXq7a9uPtovc/mdAs7dBiz1YbDdNIT3X4WmuFU78YdSYh84TXVuhOwezZ3EeKuNBhwsHQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/hoist-non-react-statics": "*",
+				"@types/react": "*",
+				"csstype": "^3.0.2"
+			}
 		},
 		"node_modules/@typescript-eslint/parser": {
 			"version": "4.29.2",
@@ -10681,6 +10703,16 @@
 			"integrity": "sha512-Myxw//kzromB9yWgS8qYGuGVf91oBUUJpNvy5eM50sqvmKLbKjwLxohJnkWGTeeI9v9IBMtPLxz5Gc60FIfvCA==",
 			"dev": true
 		},
+		"@types/hoist-non-react-statics": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+			"integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+			"dev": true,
+			"requires": {
+				"@types/react": "*",
+				"hoist-non-react-statics": "^3.3.0"
+			}
+		},
 		"@types/node": {
 			"version": "16.7.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
@@ -10708,6 +10740,17 @@
 			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
 			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
 			"dev": true
+		},
+		"@types/styled-components": {
+			"version": "5.1.14",
+			"resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.14.tgz",
+			"integrity": "sha512-d6P1/tyNytqKwam3cQXq7a9uPtovc/mdAs7dBiz1YbDdNIT3X4WmuFU78YdSYh84TXVuhOwezZ3EeKuNBhwsHQ==",
+			"dev": true,
+			"requires": {
+				"@types/hoist-non-react-statics": "*",
+				"@types/react": "*",
+				"csstype": "^3.0.2"
+			}
 		},
 		"@typescript-eslint/parser": {
 			"version": "4.29.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
 	"devDependencies": {
 		"@types/node": "^16.7.1",
 		"@types/react": "^17.0.19",
+		"@types/styled-components": "^5.1.14",
 		"eslint": "7.32.0",
 		"eslint-config-next": "11.1.0",
 		"prettier": "2.3.2",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,7 +5,7 @@
 		"baseUrl": ".",
 		"allowJs": true,
 		"skipLibCheck": true,
-		"strict": false,
+		"strict": true,
 		"forceConsistentCasingInFileNames": true,
 		"noEmit": true,
 		"esModuleInterop": true,


### PR DESCRIPTION
For nextjs, they removed strict type checking when running the development server for performance reasons. Strict types can be checked by either:
- `npm run build`
- IDE will show when the file is open

Changes included allows successful `npm run build`.

https://stackoverflow.com/questions/63556432/live-typescript-checking-with-next-js