### PR TITLE
[FE] Updated README on the disuse of next/image to retain ability for static HTML export

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,6 +1,14 @@
 {
 	"extends": "next/core-web-vitals",
 	"rules": {
-		"react/display-name": "off"
+		"react/display-name": "off",
+		"@next/next/no-img-element": "off",
+		"no-restricted-imports": [
+			"error",
+			{
+				"name": "next/image",
+				"message": "Do not use the next/image to maintain the ability to perform a static HTML export (See: https://nextjs.org/docs/advanced-features/static-html-export)"
+			}
+		]
 	}
 }

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,6 +20,19 @@ The app can be viewed at <http://localhost:3000>
 
 ## Conventions
 
+### **Build and Deployment**
+
+The intention is to build and export the frontend application using [static HTML export](https://nextjs.org/docs/advanced-features/static-html-export).
+
+Make sure that the following commands run without errors.
+
+```
+npx next build
+npx next export
+```
+
+**Note**: Please do not use `next/image` as the [server side automatic image optimisation](https://nextjs.org/docs/basic-features/image-optimization) will prevent the ability for a static HTML export. Use `<img>` instead.
+
 ### **Page URLS**
 
 Next js does auto routing with folders in the `pages` folder.
@@ -30,8 +43,8 @@ Nested folders like `frontend/pages/this-page/that-page` will link to `baseurl/t
 
 **Implemented Pages**
 
-* /shelter/home
-* /shelter/login
+-   /shelter/home
+-   /shelter/login
 
 ### **Absolute imports**
 

--- a/frontend/components/shelter/home/NoData.tsx
+++ b/frontend/components/shelter/home/NoData.tsx
@@ -1,6 +1,5 @@
 import { Button } from "antd";
 import styled from "styled-components";
-import Image from "next/image";
 
 const CenteredDiv = styled.div`
 	display: flex;
@@ -18,7 +17,7 @@ const NoData = () => {
 	return (
 		<Container>
 			<CenteredDiv>
-				<Image
+				<img
 					src="https://via.placeholder.com/97"
 					alt="Logo"
 					width="97"

--- a/frontend/layouts/shelter/ShelterLayout/HeaderContent.tsx
+++ b/frontend/layouts/shelter/ShelterLayout/HeaderContent.tsx
@@ -1,6 +1,5 @@
 import { Menu } from "antd";
 import { MenuClickEventHandler } from "rc-menu/lib/interface";
-import Image from "next/image";
 import styles from "./ShelterLayout.module.css";
 
 const logo = "/logo.png";
@@ -17,7 +16,7 @@ const HeaderContent = ({
 	handleSignOutClick
 }: Props) => {
 	const accountAvatar = (
-		<Image
+		<img
 			src="https://via.placeholder.com/32"
 			alt="avatar"
 			width="32"


### PR DESCRIPTION
Added eslint rule to enforce no import of `next/image`
Disabled Next.js eslint rule for `no-img-element`