### PR TITLE
[FE/BE] wire up shelter login

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -17,6 +17,7 @@ import uploadRouter from "./routes/upload";
 import userProfileRouter from "./routes/userProfile";
 import { ApiErrorMiddleware } from "./utils/error";
 import { Actions, setupPermissions, Subjects } from "./authorization";
+import checkPageAuth from "./helpers/checkPageAuth";
 
 // Handle Express req user
 declare module "express-serve-static-core" {
@@ -84,7 +85,7 @@ if (process.env.NODE_ENV === "development") {
 	app.use("/docs", express.static(__dirname + "/../../docs/"));
 }
 
-app.use("/", proxy(config.frontendUrl));
+app.use("/", checkPageAuth, proxy(config.frontendUrl));
 
 // logging of routes...
 app._router.stack.forEach((r: any) => {

--- a/backend/src/config/passport.ts
+++ b/backend/src/config/passport.ts
@@ -29,7 +29,7 @@ const authStrategy = (passport: passport.PassportStatic): void => {
 		"local-signup",
 		new LocalStrategy(
 			{
-				usernameField: "username",
+				usernameField: "email",
 				passwordField: "password",
 				passReqToCallback: true // allows us to pass back the entire request to the callback
 			},
@@ -78,7 +78,7 @@ const authStrategy = (passport: passport.PassportStatic): void => {
 		"local-login",
 		new LocalStrategy(
 			{
-				usernameField: "username",
+				usernameField: "email",
 				passwordField: "password",
 				passReqToCallback: false
 			},

--- a/backend/src/config/passport.ts
+++ b/backend/src/config/passport.ts
@@ -45,17 +45,17 @@ const authStrategy = (passport: passport.PassportStatic): void => {
 
 				User.findOne({
 					where: {
-						username
+						email: req.body.email
 					}
 				}).then((foundUser: User | null) => {
 					if (foundUser) {
 						return done(Error("Username taken"), null, {
-							message: "That username is already taken"
+							message: "That email address is already taken"
 						});
 					} else {
 						const userPasswordHash = generateHash(password);
 						const data: UserCreationAttributes = {
-							username,
+							username: req.body.username,
 							email: req.body.email,
 							password: userPasswordHash,
 							roles: ["ADOPTER"],
@@ -80,17 +80,22 @@ const authStrategy = (passport: passport.PassportStatic): void => {
 			{
 				usernameField: "email",
 				passwordField: "password",
-				passReqToCallback: false
+				passReqToCallback: true
 			},
-			(username: string, password: string, done) => {
+			(
+				req: express.Request,
+				username: string,
+				password: string,
+				done
+			) => {
 				User.findOne({
 					where: {
-						username
+						email: req.body.email
 					}
 				}).then((userFound: User | null) => {
 					if (userFound === null) {
 						return done(null, null, {
-							message: "Incorrect username."
+							message: "Incorrect email address."
 						});
 					} else if (
 						!bCrypt.compareSync(password, userFound.password)

--- a/backend/src/helpers/checkPageAuth.ts
+++ b/backend/src/helpers/checkPageAuth.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from "express";
+
+export default function checkPageAuth(
+	req: Request,
+	res: Response,
+	next: NextFunction
+): void {
+	const isAuthenticated = req.isAuthenticated();
+	const originalUrl = req.originalUrl;
+
+	if (isAuthenticated && originalUrl === "/shelter/login") {
+		// TODO: check if user is from a shelter, then bring redirect to shelter's home page
+		return res.redirect("/shelter/home");
+	}
+	// Users will still get any pages when unauthenticated, however API endpoints
+	// may not work for them. Black/White listing paths is troublesome and will be verbose
+	// as all requests go through express routing
+	return next();
+}

--- a/backend/src/migrations/20210822164736-create-user.ts
+++ b/backend/src/migrations/20210822164736-create-user.ts
@@ -7,10 +7,10 @@ export default {
     CREATE TABLE "user"
     (
         id         UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
-        username   VARCHAR,
-        email      VARCHAR,
-        password   VARCHAR,
-        roles      JSONB,
+        username   VARCHAR NOT NULL,
+        email      VARCHAR UNIQUE NOT NULL,
+        password   VARCHAR UNIQUE NOT NULL,
+        roles      JSONB NOT NULL,
         shelter_id UUID,
         created_at TIMESTAMP        DEFAULT current_timestamp,
         updated_at TIMESTAMP        DEFAULT current_timestamp

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -9,7 +9,7 @@ const authRouteSetup = (app: express.Application, passport: passport.PassportSta
     passport.authenticate('local-signup', (error: Error, user: User, info) => {
       if (error !== null) {
         const result = {"status": "failed", "message": "Failed to register"};
-        res.end(JSON.stringify(result));
+        return res.status(400).send(JSON.stringify(result));
       } else {
         req.login(user, (loginErr: Error) => {
           if (loginErr) {
@@ -31,7 +31,7 @@ const authRouteSetup = (app: express.Application, passport: passport.PassportSta
       }
       if (!user) {
         const result = {"status": "failure", "message": "You have entered an incorrect username or password"};
-        return res.end(JSON.stringify(result));
+        return res.status(400).send(JSON.stringify(result));
       }
       req.login(user, (loginErr: Error) => {
         if (loginErr) {
@@ -44,7 +44,7 @@ const authRouteSetup = (app: express.Application, passport: passport.PassportSta
     })(req, res, next);
   });
 
-  app.get('/api/logout', (req: express.Request, res: express.Response) => {
+  app.post('/api/logout', (req: express.Request, res: express.Response) => {
     req.logout();
     res.redirect('/');
   });

--- a/frontend/@types/global.d.ts
+++ b/frontend/@types/global.d.ts
@@ -8,9 +8,3 @@ interface Adopter {
 	status: Status;
 	image: string;
 }
-
-type LoginFormValues = {
-	username: string;
-	password: string;
-	remember?: boolean;
-};

--- a/frontend/api/createAxiosInstance.ts
+++ b/frontend/api/createAxiosInstance.ts
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+const createAxiosInstance = () => {
+	const config = {
+		baseURL: window.location.origin,
+		timeout: 30000,
+		withCredentials: true
+	};
+
+	return axios.create(config);
+};
+
+export default createAxiosInstance;

--- a/frontend/components/shelter/login/LoginForm.tsx
+++ b/frontend/components/shelter/login/LoginForm.tsx
@@ -7,6 +7,7 @@ import {
 } from "@ant-design/icons";
 import { Input, Button, QuickSignInButton } from "./components";
 import styles from "./IconStyle.module.css";
+import { LoginFormValues } from "types";
 
 type LoginFormProps = {
 	onFinish: (values: LoginFormValues) => void;
@@ -19,16 +20,17 @@ const LoginForm = ({ onFinish }: LoginFormProps) => (
 		initialValues={{ remember: true }}
 		onFinish={onFinish}>
 		<Form.Item
-			name="username"
+			name="email"
 			rules={[
 				{
+					type: "email",
 					required: true,
-					message: "Please input your Username!"
+					message: "Please input a valid Email!"
 				}
 			]}>
 			<Input
 				prefix={<UserOutlined className={styles.inputFieldIcons} />}
-				placeholder="Username"
+				placeholder="Email"
 			/>
 		</Form.Item>
 		<Form.Item
@@ -45,7 +47,7 @@ const LoginForm = ({ onFinish }: LoginFormProps) => (
 				placeholder="Password"
 			/>
 		</Form.Item>
-		<Form.Item>
+		{/* <Form.Item>
 			<Form.Item name="remember" valuePropName="checked" noStyle>
 				<Checkbox>Remember me</Checkbox>
 			</Form.Item>
@@ -53,19 +55,19 @@ const LoginForm = ({ onFinish }: LoginFormProps) => (
 			<a style={{ float: "right" }} href="">
 				Forgot password
 			</a>
-		</Form.Item>
+		</Form.Item> */}
 		<Form.Item>
 			<Button type="primary" htmlType="submit">
 				Login
 			</Button>
 		</Form.Item>
-		<Form.Item>
+		{/* <Form.Item>
 			<Row style={{ alignItems: "center" }}>
 				Quick Sign-in:{" "}
 				<QuickSignInButton size="large" icon={<GoogleOutlined />} />{" "}
 				<QuickSignInButton size="large" icon={<FacebookFilled />} />
 			</Row>
-		</Form.Item>
+		</Form.Item> */}
 	</Form>
 );
 

--- a/frontend/components/shelter/login/SignUpForm.tsx
+++ b/frontend/components/shelter/login/SignUpForm.tsx
@@ -7,6 +7,7 @@ import {
 	FacebookFilled
 } from "@ant-design/icons";
 import styles from "./IconStyle.module.css";
+import { LoginFormValues } from "types";
 
 type SignUpFormProps = {
 	onFinish: (values: LoginFormValues) => void;
@@ -14,16 +15,16 @@ type SignUpFormProps = {
 const SignUpForm = ({ onFinish }: SignUpFormProps) => (
 	<Form name="signup" className="signup-form" onFinish={onFinish}>
 		<Form.Item
-			name="username"
+			name="email"
 			rules={[
 				{
 					required: true,
-					message: "Please input your Username!"
+					message: "Please input a valid Email!"
 				}
 			]}>
 			<Input
 				prefix={<UserOutlined className={styles.inputFieldIcons} />}
-				placeholder="Username"
+				placeholder="Email"
 			/>
 		</Form.Item>
 		<Form.Item
@@ -31,7 +32,7 @@ const SignUpForm = ({ onFinish }: SignUpFormProps) => (
 			rules={[
 				{
 					required: true,
-					message: "Please input your Password!"
+					message: "Please input a Password!"
 				}
 			]}>
 			<Input.Password
@@ -42,16 +43,16 @@ const SignUpForm = ({ onFinish }: SignUpFormProps) => (
 		</Form.Item>
 		<Form.Item>
 			<Button type="primary" htmlType="submit">
-				Login
+				Sign Up
 			</Button>
 		</Form.Item>
-		<Form.Item>
+		{/* <Form.Item>
 			<Row style={{ alignItems: "center" }}>
 				Sign up with:{" "}
 				<QuickSignInButton size="large" icon={<GoogleOutlined />} />{" "}
 				<QuickSignInButton size="large" icon={<FacebookFilled />} />
 			</Row>
-		</Form.Item>
+		</Form.Item> */}
 	</Form>
 );
 

--- a/frontend/layouts/shelter/ShelterLayout/index.tsx
+++ b/frontend/layouts/shelter/ShelterLayout/index.tsx
@@ -1,4 +1,5 @@
 import { Layout } from "antd";
+import createAxiosInstance from "api/createAxiosInstance";
 import { ReactNode } from "react";
 import HeaderContent from "./HeaderContent";
 import LeftMenu from "./LeftMenu";
@@ -17,8 +18,17 @@ const ShelterLayout = ({ children }: Props) => {
 	const handleEditProfileClick = () => {
 		alert("Edit Profile");
 	};
-	const handleSignOutClick = () => {
-		alert("Sign Out");
+
+	const onClickSignOut = async () => {
+		try {
+			const axios = createAxiosInstance();
+			const {
+				data: { payload }
+			} = await axios.post("/api/logout");
+			window.location.assign("/shelter/login");
+		} catch (err) {
+			console.log(err);
+		}
 	};
 
 	return (
@@ -26,7 +36,7 @@ const ShelterLayout = ({ children }: Props) => {
 			<Header className={header}>
 				<HeaderContent
 					handleEditProfileClick={handleEditProfileClick}
-					handleSignOutClick={handleSignOutClick}
+					handleSignOutClick={onClickSignOut}
 				/>
 			</Header>
 			<Layout>

--- a/frontend/pages/shelter/login.tsx
+++ b/frontend/pages/shelter/login.tsx
@@ -4,13 +4,35 @@ import LogoHeader from "components/shelter/login/LogoHeader";
 import SignUpForm from "components/shelter/login/SignUpForm";
 import ShelterLoginLayout from "layouts/shelter/ShelterLoginLayout";
 import styled from "styled-components";
+import createAxiosInstance from "api/createAxiosInstance";
+import { LoginFormValues } from "types";
 
 const { TabPane } = Tabs;
 
 const ShelterLogin = () => {
-	const onFinish = (values: LoginFormValues) => {
-		alert("login");
-		console.log("Received values of form: ", values);
+	const onSubmitLogin = async (values: LoginFormValues) => {
+		try {
+			const axios = createAxiosInstance();
+			const {
+				data: { payload }
+			} = await axios.post("/api/login", values);
+			window.location.assign("/shelter/home");
+		} catch (err) {
+			// TODO: handle error in UI
+			console.log(err);
+		}
+	};
+	const onSubmitSignup = async (values: LoginFormValues) => {
+		try {
+			const axios = createAxiosInstance();
+			const {
+				data: { payload }
+			} = await axios.post("/api/register", values);
+			window.location.assign("/shelter/home");
+		} catch (err) {
+			// TODO: handle error in UI
+			console.log(err);
+		}
 	};
 
 	return (
@@ -21,10 +43,10 @@ const ShelterLogin = () => {
 						<LogoHeader />
 						<StyledTabs defaultActiveKey="1">
 							<TabPane tab="Login" key="1">
-								<LoginForm onFinish={onFinish} />
+								<LoginForm onFinish={onSubmitLogin} />
 							</TabPane>
 							<TabPane tab="Signup" key="2">
-								<SignUpForm onFinish={onFinish} />
+								<SignUpForm onFinish={onSubmitSignup} />
 							</TabPane>
 						</StyledTabs>
 					</LoginContainer>

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -1,0 +1,5 @@
+export type LoginFormValues = {
+	username: string;
+	password: string;
+	remember?: boolean;
+};


### PR DESCRIPTION

Changes:
- changed to use email instead of username as login id
- added constraints to user migrations
- redirect from /shelter/login to /shelter/home when login or register successful
- redirect to /shelter/login when Sign out at top right corner is clicked
 
To test:
- drop db, create db, `npm run db:migrate` in backend
- `npm run dev` in frontend
- `npm start` in backend
- visit http://localhost/shelter/login
- register, login and logout

