### PR TITLE
Use Node 16 LTS to avoid build issues

### DIFF
--- a/.github/workflows/test-and-compile.yml
+++ b/.github/workflows/test-and-compile.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Install Packages
         working-directory: ./backend
         run: npm install
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Install Packages
         working-directory: ./frontend
         run: npm install
@@ -36,4 +36,3 @@ jobs:
       - name: Compile Typescript
         working-directory: ./frontend
         run: npm run build
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:16
 COPY . /app
 
 


### PR DESCRIPTION
Build having issues with latest node version when. Set to Node 16 LTS to fix.

See https://stackoverflow.com/a/69732182/2085381

```
 > [ 5/15] RUN npm run build:                                                                                                    
#8 2.262                                                                                                                         
#8 2.262 > paw-frontend@1.0.0 build                                                                                              
#8 2.262 > next build                                                                                                            
#8 2.262                                                                                                                         
#8 7.283 info  - Using webpack 5. Reason: Enabled by default https://nextjs.org/docs/messages/webpack5
#8 7.915 Attention: Next.js now collects completely anonymous telemetry regarding usage.
#8 7.916 This information is used to shape Next.js' roadmap and prioritize features.
#8 7.916 You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
#8 7.916 https://nextjs.org/telemetry
#8 7.916 
#8 8.485 info  - Checking validity of types...
#8 48.67 info  - Creating an optimized production build...
#8 51.31 node:internal/crypto/hash:67
#8 51.31   this[kHandle] = new _Hash(algorithm, xofLen);
#8 51.31                   ^
#8 51.31 
#8 51.31 Error: error:0308010C:digital envelope routines::unsupported
#8 51.31     at new Hash (node:internal/crypto/hash:67:19)
#8 51.31     at Object.createHash (node:crypto:130:10)
#8 51.31     at BulkUpdateDecorator.hashFactory (/app/frontend/node_modules/next/dist/compiled/webpack/bundle5.js:138458:18)
#8 51.31     at BulkUpdateDecorator.update (/app/frontend/node_modules/next/dist/compiled/webpack/bundle5.js:138359:50)
#8 51.31     at /app/frontend/node_modules/next/dist/compiled/webpack/bundle5.js:59115:9
#8 51.31     at processTicksAndRejections (node:internal/process/task_queues:83:21)
#8 51.31     at runNextTicks (node:internal/process/task_queues:65:3)
#8 51.31     at processImmediate (node:internal/timers:437:9) {
#8 51.31   opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
#8 51.31   library: 'digital envelope routines',
#8 51.31   reason: 'unsupported',
#8 51.31   code: 'ERR_OSSL_EVP_UNSUPPORTED'
#8 51.31 }
#8 51.31 
#8 51.31 Node.js v17.1.0
```