### PR TITLE
[BE] Request logging

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -18,6 +18,7 @@ import { HealthCheckController } from "./controllers/healthcheck";
 import { ShelterController } from "./controllers/shelter";
 import { UploadController } from "./controllers/upload";
 import checkPageAuth from "./helpers/checkPageAuth";
+import { LoggerContextMiddleware } from "./helpers/logger";
 import { User as UserType } from "./models/user";
 import authRouteSetup from "./routes/auth";
 import bookingRouter from "./routes/booking";
@@ -56,6 +57,8 @@ if (config.nodeEnv === "development") {
 
 setupSession(app);
 
+app.use(LoggerContextMiddleware);
+
 // Passport initialization
 app.use(passport.initialize());
 app.use(passport.session());
@@ -85,7 +88,12 @@ app.use("/api", bookingRouter);
 app.use("/api", userProfileRouter);
 
 useExpressServer(app, {
-	controllers: [AnimalController, ShelterController, HealthCheckController, UploadController],
+	controllers: [
+		AnimalController,
+		ShelterController,
+		HealthCheckController,
+		UploadController,
+	],
 	development: false,
 	defaultErrorHandler: false,
 	middlewares: [ApiErrorMiddleware],

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -52,6 +52,7 @@ const otherConfigs = {
 	],
 	nodeEnv: validEnv.NODE_ENV,
 	logMaxStringLength: 1000,
+	logLevel: "info",
 };
 
 const config = {

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -51,6 +51,7 @@ const otherConfigs = {
 		"http://localhost:3000",
 	],
 	nodeEnv: validEnv.NODE_ENV,
+	logMaxStringLength: 1000,
 };
 
 const config = {

--- a/backend/src/controllers/animal.ts
+++ b/backend/src/controllers/animal.ts
@@ -15,7 +15,6 @@ import {
 	Req,
 } from "routing-controllers";
 import { WhereOptions } from "sequelize/types";
-import { Logger } from "../helpers/logger";
 import { z } from "zod";
 import { sequelize } from "../database";
 import { AnimalModel } from "../models/animal";

--- a/backend/src/controllers/animal.ts
+++ b/backend/src/controllers/animal.ts
@@ -15,6 +15,7 @@ import {
 	Req,
 } from "routing-controllers";
 import { WhereOptions } from "sequelize/types";
+import { Logger } from "../helpers/logger";
 import { z } from "zod";
 import { sequelize } from "../database";
 import { AnimalModel } from "../models/animal";
@@ -77,7 +78,7 @@ export class AnimalController {
 		}
 
 		const animal = await this.createAnimal(input);
-		console.log(`Created animal with id ${animal.id}`);
+		Logger.log(`Created animal with id ${animal.id}`);
 	}
 
 	private async createAnimal(
@@ -124,7 +125,7 @@ export class AnimalController {
 		}
 
 		await this.updateAnimal(animal, input);
-		console.log(`Updated animal with id ${animal.id}`);
+		Logger.log(`Updated animal with id ${animal.id}`);
 	}
 
 	private async updateAnimal(
@@ -175,7 +176,7 @@ export class AnimalController {
 
 		// records in animal image table are automatically deleted
 		await animal.destroy();
-		console.log(`Deleted animal with id ${animal.id}`);
+		Logger.log(`Deleted animal with id ${animal.id}`);
 	}
 }
 

--- a/backend/src/controllers/animal.ts
+++ b/backend/src/controllers/animal.ts
@@ -77,7 +77,7 @@ export class AnimalController {
 		}
 
 		const animal = await this.createAnimal(input);
-		Logger.log(`Created animal with id ${animal.id}`);
+		Logger.info(`Created animal with id ${animal.id}`);
 	}
 
 	private async createAnimal(
@@ -124,7 +124,7 @@ export class AnimalController {
 		}
 
 		await this.updateAnimal(animal, input);
-		Logger.log(`Updated animal with id ${animal.id}`);
+		Logger.info(`Updated animal with id ${animal.id}`);
 	}
 
 	private async updateAnimal(
@@ -175,7 +175,7 @@ export class AnimalController {
 
 		// records in animal image table are automatically deleted
 		await animal.destroy();
-		Logger.log(`Deleted animal with id ${animal.id}`);
+		Logger.info(`Deleted animal with id ${animal.id}`);
 	}
 }
 

--- a/backend/src/controllers/shelter.ts
+++ b/backend/src/controllers/shelter.ts
@@ -1,32 +1,45 @@
-import { Body, Get, JsonController, OnUndefined, Param, Post } from 'routing-controllers';
-import { ShelterAttributes, ShelterCreationAttributes, ShelterModel } from "../models/shelter";
+import {
+	Body,
+	Get,
+	JsonController,
+	OnUndefined,
+	Param,
+	Post,
+} from "routing-controllers";
+import {
+	ShelterAttributes,
+	ShelterCreationAttributes,
+	ShelterModel,
+} from "../models/shelter";
 
-@JsonController('/api/shelter')
+@JsonController("/api/shelter")
 export class ShelterController {
-  @Get('/')
-  async getAll(): Promise<ShelterAttributes[]> {
-    const shelters = await ShelterModel.findAll();
-    return shelters.map(s => s.get({ plain: true }));
-  }
+	@Get("/")
+	async getAll(): Promise<ShelterAttributes[]> {
+		const shelters = await ShelterModel.findAll();
+		return shelters.map((s) => s.get({ plain: true }));
+	}
 
-  @Get('/:id')
-  @OnUndefined(404)
-  async getById(@Param("id") id: string): Promise<ShelterAttributes | undefined> {
-    const animal = await ShelterModel.findByPk(id);
-    return animal?.get({ plain: true });
-  }
+	@Get("/:id")
+	@OnUndefined(404)
+	async getById(
+		@Param("id") id: string,
+	): Promise<ShelterAttributes | undefined> {
+		const animal = await ShelterModel.findByPk(id);
+		return animal?.get({ plain: true });
+	}
 
-  @Post('/')
-  @OnUndefined(201)
-  async create(@Body() shelter: ShelterCreationAttributes): Promise<void>{
-    const data:ShelterCreationAttributes = {
-      name: shelter.name,
-      address: shelter.address,
-      country: shelter.country,
-      contact: shelter.contact,
-      registrationNo: shelter.registrationNo,
-    }
-    const s = await ShelterModel.create(data);
-    console.debug(`Saved shelter ${s.id}`);
-  }
+	@Post("/")
+	@OnUndefined(201)
+	async create(@Body() shelter: ShelterCreationAttributes): Promise<void> {
+		const data: ShelterCreationAttributes = {
+			name: shelter.name,
+			address: shelter.address,
+			country: shelter.country,
+			contact: shelter.contact,
+			registrationNo: shelter.registrationNo,
+		};
+		const s = await ShelterModel.create(data);
+		Logger.info(`Saved shelter ${s.id}`);
+	}
 }

--- a/backend/src/controllers/upload.ts
+++ b/backend/src/controllers/upload.ts
@@ -5,13 +5,13 @@ import express from "express";
 import FileType from "file-type";
 import mime from "mime-types";
 import {
-  BadRequestError,
-  Get,
-  JsonController,
-  NotFoundError,
-  Post,
-  Req,
-  UseBefore,
+	BadRequestError,
+	Get,
+	JsonController,
+	NotFoundError,
+	Post,
+	Req,
+	UseBefore,
 } from "routing-controllers";
 import sharp from "sharp";
 import { Readable } from "stream";
@@ -24,241 +24,241 @@ import { zodBase64FileSchema } from "../utils/validation";
 const MAX_FILE_SIZE_MB = 10;
 const MAX_IMAGE_SIZE_MB = 5;
 const ALLOWED_FILE_MIME_TYPES = [
-  "image/png",
-  "image/jpeg",
-  "video/mp4",
-  "application/pdf",
-  "application/msword",
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-  "text/plain",
+	"image/png",
+	"image/jpeg",
+	"video/mp4",
+	"application/pdf",
+	"application/msword",
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	"text/plain",
 ];
 const ALLOWED_IMAGE_MIME_TYPES = ["image/png", "image/jpeg"];
 
 let storage = new Storage();
 
 if (fullConfig.googleSvcAcctKey !== "") {
-  storage = new Storage({ keyFilename: fullConfig.googleSvcAcctKey });
+	storage = new Storage({ keyFilename: fullConfig.googleSvcAcctKey });
 }
 
 const storageBucketName = fullConfig.storageBucketName;
 
 const UploadRequestQuerySchema = z.object({
-  originalFileName: z.string(),
-  base64File: zodBase64FileSchema(MAX_FILE_SIZE_MB),
+	originalFileName: z.string(),
+	base64File: zodBase64FileSchema(MAX_FILE_SIZE_MB),
 });
 
 const UploadImageRequestQuerySchema = z.object({
-  originalFileName: z.string(),
-  base64File: zodBase64FileSchema(MAX_IMAGE_SIZE_MB),
+	originalFileName: z.string(),
+	base64File: zodBase64FileSchema(MAX_IMAGE_SIZE_MB),
 });
 
 @JsonController("/api/upload")
 export class UploadController {
-  @Post()
-  @UseBefore(IsLoggedInMiddleware)
-  async upload(
-    @Req() req: express.Request,
-  ): Promise<Upload.uploadApiDomain.response> {
-    const input = UploadRequestQuerySchema.parse(req.body);
+	@Post()
+	@UseBefore(IsLoggedInMiddleware)
+	async upload(
+		@Req() req: express.Request,
+	): Promise<Upload.uploadApiDomain.response> {
+		const input = UploadRequestQuerySchema.parse(req.body);
 
-    const {
-      buffer,
-      mimeType,
-      extension,
-    } = await this.validateAndExtractFileInfo(
-      input,
-      ALLOWED_FILE_MIME_TYPES,
-    );
+		const { buffer, mimeType, extension } =
+			await this.validateAndExtractFileInfo(
+				input,
+				ALLOWED_FILE_MIME_TYPES,
+			);
 
-    const newFileName = makeRandomName() + "." + extension;
+		const newFileName = makeRandomName() + "." + extension;
 
-    await this.saveBufferToBucket(newFileName, mimeType, buffer);
+		await this.saveBufferToBucket(newFileName, mimeType, buffer);
 
-    const uploadRecord = {
-      userId: req.user.id,
-      originalFilename: input.originalFileName,
-      filename: newFileName,
-    };
-    await UploadModel.create(uploadRecord);
+		const uploadRecord = {
+			userId: req.user.id,
+			originalFilename: input.originalFileName,
+			filename: newFileName,
+		};
+		await UploadModel.create(uploadRecord);
 
-    return {
-      message: "You have successfully uploaded the file",
-      payload: {
-        originalFileName: input.originalFileName,
-        fileName: newFileName,
-        url: `https://storage.googleapis.com/${storageBucketName}/${newFileName}`,
-      },
-    };
-  }
+		return {
+			message: "You have successfully uploaded the file",
+			payload: {
+				originalFileName: input.originalFileName,
+				fileName: newFileName,
+				url: `https://storage.googleapis.com/${storageBucketName}/${newFileName}`,
+			},
+		};
+	}
 
-  @Post("/image")
-  @UseBefore(IsLoggedInMiddleware)
-  async uploadImage(
-    @Req() req: express.Request,
-  ): Promise<Upload.uploadImageApiDomain.response> {
-    const input = UploadImageRequestQuerySchema.parse(req.body);
+	@Post("/image")
+	@UseBefore(IsLoggedInMiddleware)
+	async uploadImage(
+		@Req() req: express.Request,
+	): Promise<Upload.uploadImageApiDomain.response> {
+		const input = UploadImageRequestQuerySchema.parse(req.body);
 
-    const { buffer } = await this.validateAndExtractFileInfo(
-      input,
-      ALLOWED_IMAGE_MIME_TYPES,
-    );
+		const { buffer } = await this.validateAndExtractFileInfo(
+			input,
+			ALLOWED_IMAGE_MIME_TYPES,
+		);
 
-    const imageBuffer = await this.resizeAndConvertImageToJpeg(buffer, { width: 1000 });
-    const thumbnailBuffer = await this.resizeAndConvertImageToJpeg(buffer, {
-      width: 500,
-      height: 500,
-    });
+		const imageBuffer = await this.resizeAndConvertImageToJpeg(buffer, {
+			width: 1000,
+		});
+		const thumbnailBuffer = await this.resizeAndConvertImageToJpeg(buffer, {
+			width: 500,
+			height: 500,
+		});
 
-    const newFileName = makeRandomName();
-    const imageFileName = newFileName + ".jpg";
-    const thumbnailFileName = newFileName + "_thumbnail.jpg";
+		const newFileName = makeRandomName();
+		const imageFileName = newFileName + ".jpg";
+		const thumbnailFileName = newFileName + "_thumbnail.jpg";
 
-    await this.saveBufferToBucket(imageFileName, "image/jpeg", imageBuffer);
-    await this.saveBufferToBucket(
-      thumbnailFileName,
-      "image/jpeg",
-      thumbnailBuffer,
-    );
+		await this.saveBufferToBucket(imageFileName, "image/jpeg", imageBuffer);
+		await this.saveBufferToBucket(
+			thumbnailFileName,
+			"image/jpeg",
+			thumbnailBuffer,
+		);
 
-    await UploadModel.create({
-      userId: req.user.id,
-      originalFilename: input.originalFileName,
-      filename: imageFileName,
-    });
+		await UploadModel.create({
+			userId: req.user.id,
+			originalFilename: input.originalFileName,
+			filename: imageFileName,
+		});
 
-    await UploadModel.create({
-      userId: req.user.id,
-      originalFilename: input.originalFileName,
-      filename: thumbnailFileName,
-    });
+		await UploadModel.create({
+			userId: req.user.id,
+			originalFilename: input.originalFileName,
+			filename: thumbnailFileName,
+		});
 
-    return {
-      message: "You have successfully uploaded the file",
-      payload: {
-        originalFileName: input.originalFileName,
-        fileName: imageFileName,
-        url: `https://storage.googleapis.com/${storageBucketName}/${imageFileName}`,
-        thumbnailUrl: `https://storage.googleapis.com/${storageBucketName}/${thumbnailFileName}`,
-      },
-    };
-  }
+		return {
+			message: "You have successfully uploaded the file",
+			payload: {
+				originalFileName: input.originalFileName,
+				fileName: imageFileName,
+				url: `https://storage.googleapis.com/${storageBucketName}/${imageFileName}`,
+				thumbnailUrl: `https://storage.googleapis.com/${storageBucketName}/${thumbnailFileName}`,
+			},
+		};
+	}
 
-  @Get("/:uploadId")
-  @UseBefore(IsLoggedInMiddleware)
-  async download(
-    @Req() req: express.Request,
-  ): Promise<Upload.downloadApiDomain.response> {
-    // the below checks for file ID & user ID authorization
-    const upload = await UploadModel.findOne({
-      where: {
-        id: req.params.uploadId,
-        userId: req.user.id,
-      },
-    });
+	@Get("/:uploadId")
+	@UseBefore(IsLoggedInMiddleware)
+	async download(
+		@Req() req: express.Request,
+	): Promise<Upload.downloadApiDomain.response> {
+		// the below checks for file ID & user ID authorization
+		const upload = await UploadModel.findOne({
+			where: {
+				id: req.params.uploadId,
+				userId: req.user.id,
+			},
+		});
 
-    if (!upload) {
-      throw new NotFoundError("File ID does not exist");
-    }
+		if (!upload) {
+			throw new NotFoundError("File ID does not exist");
+		}
 
-    const filename = upload.filename;
+		const filename = upload.filename;
 
-    const fileStream = storage
-      .bucket(storageBucketName)
-      .file(filename)
-      .createReadStream();
+		const fileStream = storage
+			.bucket(storageBucketName)
+			.file(filename)
+			.createReadStream();
 
-    const base64Content = await streamToString(fileStream);
-    const result = {
-      status: "success",
-      message: "",
-      payload: base64Content,
-    };
-    return result;
-  }
+		const base64Content = await streamToString(fileStream);
+		const result = {
+			status: "success",
+			message: "",
+			payload: base64Content,
+		};
+		return result;
+	}
 
-  private async validateAndExtractFileInfo(
-    input: z.infer<typeof UploadRequestQuerySchema>,
-    allowedMimeTypes: string[],
-  ) {
-    const buffer = Buffer.from(input.base64File, "base64");
-    const fileType = await FileType.fromBuffer(buffer);
-    const mimeTypeFromExt = mime.lookup(input.originalFileName);
+	private async validateAndExtractFileInfo(
+		input: z.infer<typeof UploadRequestQuerySchema>,
+		allowedMimeTypes: string[],
+	) {
+		const buffer = Buffer.from(input.base64File, "base64");
+		const fileType = await FileType.fromBuffer(buffer);
+		const mimeTypeFromExt = mime.lookup(input.originalFileName);
 
-    if (!fileType) {
-      throw new BadRequestError("Invalid file: no mime type detected");
-    }
+		if (!fileType) {
+			throw new BadRequestError("Invalid file: no mime type detected");
+		}
 
-    if (!mimeTypeFromExt) {
-      throw new BadRequestError("Invalid file: missing extension");
-    }
+		if (!mimeTypeFromExt) {
+			throw new BadRequestError("Invalid file: missing extension");
+		}
 
-    if (mimeTypeFromExt !== fileType.mime) {
-      throw new BadRequestError(
-        "Invalid file: mismatched type and extension",
-      );
-    }
+		if (mimeTypeFromExt !== fileType.mime) {
+			throw new BadRequestError(
+				"Invalid file: mismatched type and extension",
+			);
+		}
 
-    if (!allowedMimeTypes.includes(mimeTypeFromExt)) {
-      throw new BadRequestError("Invalid file: mime type not allowed");
-    }
+		if (!allowedMimeTypes.includes(mimeTypeFromExt)) {
+			throw new BadRequestError("Invalid file: mime type not allowed");
+		}
 
-    return { buffer, mimeType: fileType.mime, extension: fileType.ext };
-  }
+		return { buffer, mimeType: fileType.mime, extension: fileType.ext };
+	}
 
-  private async resizeAndConvertImageToJpeg(
-    buffer: Buffer,
-    options: { width?: number; height?: number },
-  ) {
-    return await sharp(buffer)
-      .resize({ width: options.width, height: options.height, withoutEnlargement: true })
-      .jpeg({ mozjpeg: true })
-      .toBuffer();
-  }
+	private async resizeAndConvertImageToJpeg(
+		buffer: Buffer,
+		options: { width?: number; height?: number },
+	) {
+		return await sharp(buffer)
+			.resize({
+				width: options.width,
+				height: options.height,
+				withoutEnlargement: true,
+			})
+			.jpeg({ mozjpeg: true })
+			.toBuffer();
+	}
 
-  private async saveBufferToBucket(
-    fileName: string,
-    mimeType: string,
-    buffer: Buffer,
-  ) {
-    const uploadBucket = storage.bucket(storageBucketName);
-    const file = uploadBucket.file(fileName);
+	private async saveBufferToBucket(
+		fileName: string,
+		mimeType: string,
+		buffer: Buffer,
+	) {
+		const uploadBucket = storage.bucket(storageBucketName);
+		const file = uploadBucket.file(fileName);
 
-    try {
-      await file.save(buffer, { contentType: mimeType });
-    } catch (err) {
-      console.log(
-        "Error during file upload: " +
-        (err instanceof Error ? err.message : "unknown"),
-      );
-      throw new Error("Failed to upload file");
-    }
-  }
+		try {
+			await file.save(buffer, { contentType: mimeType });
+		} catch (err) {
+			Logger.error("Error during file upload", err);
+			throw new Error("Failed to upload file");
+		}
+	}
 }
 
 function makeRandomName(): string {
-  let result = "";
-  const characters =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  const charactersLength = 29;
-  for (let i = 0; i < charactersLength; i++) {
-    if (i % 5 === 4) {
-      result += "-";
-    } else {
-      result += characters.charAt(crypto.randomInt(0, characters.length));
-    }
-  }
-  return result;
+	let result = "";
+	const characters =
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+	const charactersLength = 29;
+	for (let i = 0; i < charactersLength; i++) {
+		if (i % 5 === 4) {
+			result += "-";
+		} else {
+			result += characters.charAt(crypto.randomInt(0, characters.length));
+		}
+	}
+	return result;
 }
 
 async function streamToString(stream: Readable): Promise<string> {
-  const chunks: Uint8Array[] = [];
-  return new Promise((resolve, reject) => {
-    stream.on("data", (chunk: Uint8Array) =>
-      chunks.push(Buffer.from(chunk)),
-    );
-    stream.on("error", (err) => reject(err));
-    stream.on("end", () =>
-      resolve(Buffer.concat(chunks).toString("base64")),
-    );
-  });
+	const chunks: Uint8Array[] = [];
+	return new Promise((resolve, reject) => {
+		stream.on("data", (chunk: Uint8Array) =>
+			chunks.push(Buffer.from(chunk)),
+		);
+		stream.on("error", (err) => reject(err));
+		stream.on("end", () =>
+			resolve(Buffer.concat(chunks).toString("base64")),
+		);
+	});
 }

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -3,6 +3,7 @@ import allConfig from "./config/config";
 
 // eslint-disable-next-line
 const config: any = allConfig.databaseConfig;
+config.logging = (msg: any) => Logger.debug(msg);
 export const sequelize = new Sequelize(
 	config.database,
 	config.username,
@@ -13,9 +14,9 @@ export const sequelize = new Sequelize(
 const testConnection = async () => {
 	try {
 		await sequelize.authenticate();
-		console.log("Connection has been established successfully.");
+		Logger.info("Connection has been established successfully.");
 	} catch (error) {
-		console.error("Unable to connect to the database:", error);
+		Logger.fatal("Unable to connect to the database:", error);
 		throw error;
 	}
 };

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -3,7 +3,7 @@ import allConfig from "./config/config";
 
 // eslint-disable-next-line
 const config: any = allConfig.databaseConfig;
-config.logging = (msg: any) => Logger.debug(msg);
+config.logging = (sql: string) => Logger.debug(sql);
 export const sequelize = new Sequelize(
 	config.database,
 	config.username,

--- a/backend/src/helpers/logger.ts
+++ b/backend/src/helpers/logger.ts
@@ -12,12 +12,39 @@ export const requestContextLocalStorage =
 	new AsyncLocalStorage<RequestContext>();
 
 export class Logger {
-	static log(...message: any[]) {
+	static log(message: string, ...data: any[]) {
 		const context = requestContextLocalStorage.getStore();
-		console.log({
-			context,
-			message,
-		});
+		console.dir(
+			{
+				req: {
+					url: context?.req.path,
+					id: context?.id,
+					timestamp: new Date().toISOString(),
+				},
+				level: "info",
+				message,
+				data,
+			},
+			// customise depth so that nested objects can be printed and limit long string
+			{ depth: 5, maxStringLength: 1000 },
+		);
+	}
+
+	static error(message: string, ...data: any[]) {
+		const context = requestContextLocalStorage.getStore();
+		console.dir(
+			{
+				req: {
+					url: context?.req.path,
+					id: context?.id,
+					timestamp: new Date().toISOString(),
+				},
+				level: "error",
+				message,
+				data,
+			},
+			{ depth: 5, maxStringLength: 1000 },
+		);
 	}
 }
 

--- a/backend/src/helpers/logger.ts
+++ b/backend/src/helpers/logger.ts
@@ -1,3 +1,5 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+
 import { AsyncLocalStorage, AsyncResource } from "async_hooks";
 import crypto from "crypto";
 import { Request, RequestHandler } from "express";
@@ -54,7 +56,7 @@ export class Logger {
 	private static logLevel =
 		LogToLogLevelMap[config.logLevel ?? "info"] ?? LogLevel.Info;
 
-	static setLogLevel(logLevel: string) {
+	static setLogLevel(logLevel: string): void {
 		if (LogToLogLevelMap[logLevel] === undefined) {
 			throw new Error("Invalid log level");
 		}

--- a/backend/src/helpers/logger.ts
+++ b/backend/src/helpers/logger.ts
@@ -108,11 +108,12 @@ export class Logger {
 			severity: severity,
 		};
 
-		const trace = context?.req.header("X-Cloud-Trace-Context");
-		if (trace) {
+		const traceHeader = context?.req.header("X-Cloud-Trace-Context");
+		if (traceHeader) {
+			const [traceId] = traceHeader.split("/");
 			payload[
 				"logging.googleapis.com/trace"
-			] = `projects/pawscore/traces/${trace}`;
+			] = `projects/pawscore/traces/${traceId}`;
 		}
 
 		return payload;

--- a/backend/src/helpers/logger.ts
+++ b/backend/src/helpers/logger.ts
@@ -1,6 +1,14 @@
 import { AsyncLocalStorage, AsyncResource } from "async_hooks";
 import crypto from "crypto";
 import { Request, RequestHandler } from "express";
+import config from "../config/config";
+
+declare global {
+	class Logger {
+		static log(message: string, ...data: any[]): void;
+		static error(message: string, ...data: any[]): void;
+	}
+}
 
 type RequestContext = {
 	id: string;
@@ -11,39 +19,92 @@ type RequestContext = {
 export const requestContextLocalStorage =
 	new AsyncLocalStorage<RequestContext>();
 
+// fields picked up by Cloud Logging
+type GoogleStructuredJSON = {
+	severity: string;
+	message: string;
+	timestamp: string;
+	"logging.googleapis.com/trace"?: string;
+	[key: string]: any;
+};
+
+const sensitiveFields = ["password"];
+
 export class Logger {
-	static log(message: string, ...data: any[]) {
+	static log(message: string, ...data: any[]): void {
 		const context = requestContextLocalStorage.getStore();
-		console.dir(
-			{
-				req: {
-					url: context?.req.path,
-					id: context?.id,
-					timestamp: new Date().toISOString(),
-				},
-				level: "info",
-				message,
-				data,
+
+		const payload: GoogleStructuredJSON = {
+			req: {
+				url: context?.req.path,
+				id: context?.id,
 			},
-			// customise depth so that nested objects can be printed and limit long string
-			{ depth: 5, maxStringLength: 1000 },
-		);
+			timestamp: new Date().toISOString(),
+			severity: "INFO",
+			message,
+			data,
+		};
+
+		const trace = context?.req.header("X-Cloud-Trace-Context");
+		if (trace) {
+			payload[
+				"logging.googleapis.com/trace"
+			] = `projects/pawscore/traces/${trace}`;
+		}
+
+		console.log(Logger.stringify(payload));
 	}
 
-	static error(message: string, ...data: any[]) {
+	static error(message: string, ...data: any[]): void {
 		const context = requestContextLocalStorage.getStore();
-		console.dir(
-			{
-				req: {
-					url: context?.req.path,
-					id: context?.id,
-					timestamp: new Date().toISOString(),
-				},
-				level: "error",
-				message,
-				data,
+
+		const payload: GoogleStructuredJSON = {
+			req: {
+				url: context?.req.path,
+				id: context?.id,
 			},
-			{ depth: 5, maxStringLength: 1000 },
+			timestamp: new Date().toISOString(),
+			severity: "ERROR",
+			message,
+			data,
+		};
+
+		const trace = context?.req.header("X-Cloud-Trace-Context");
+		if (trace) {
+			payload[
+				"logging.googleapis.com/trace"
+			] = `projects/pawscore/traces/${trace}`;
+		}
+
+		console.log(Logger.stringify(payload));
+	}
+
+	private static stringify(payload: any) {
+		const indentation = ["development", "test"].includes(config.nodeEnv)
+			? 2
+			: undefined;
+
+		// TODO: max depth
+		return JSON.stringify(
+			payload,
+			function (k, v) {
+				// blacklist sensitive data
+				// TODO: masking function for fields like email?
+				if (sensitiveFields.includes(k.toLowerCase())) {
+					return "[Redacted]";
+				}
+
+				// limit string length
+
+				if (typeof v === "string") {
+					return v.length > config.logMaxStringLength
+						? v.substring(0, config.logMaxStringLength) + "[...]"
+						: v;
+				}
+
+				return v;
+			},
+			indentation,
 		);
 	}
 }

--- a/backend/src/helpers/logger.ts
+++ b/backend/src/helpers/logger.ts
@@ -1,0 +1,45 @@
+import { AsyncLocalStorage, AsyncResource } from "async_hooks";
+import crypto from "crypto";
+import { Request, RequestHandler } from "express";
+
+type RequestContext = {
+	id: string;
+	req: Request;
+};
+
+// set up a store to persist data through async operations, making them accessible from nested calls
+export const requestContextLocalStorage =
+	new AsyncLocalStorage<RequestContext>();
+
+export class Logger {
+	static log(...message: any[]) {
+		const context = requestContextLocalStorage.getStore();
+		console.log({
+			context,
+			message,
+		});
+	}
+}
+
+export const LoggerContextMiddleware: RequestHandler = (req, res, next) => {
+	const context = {
+		id: crypto.randomUUID(),
+		req,
+	};
+
+	requestContextLocalStorage.run(context, () => {
+		Logger.log("Request start", {
+			body: req.body,
+			query: req.query,
+		});
+		// successful responses strangely do not emit `finish`, use `close`
+		res.on(
+			"close",
+			// binding required as context was lost
+			AsyncResource.bind(() => {
+				Logger.log("Request end", { status: res.statusCode });
+			}),
+		);
+		next();
+	});
+};

--- a/backend/src/helpers/tests/__snapshots__/logger.test.ts.snap
+++ b/backend/src/helpers/tests/__snapshots__/logger.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Logger should extract req information when available 1`] = `"{\\"req\\":{\\"url\\":\\"reqPath\\",\\"id\\":\\"reqId\\"},\\"timestamp\\":\\"2022-01-31T16:00:00.000Z\\",\\"severity\\":\\"INFO\\",\\"logging.googleapis.com/trace\\":\\"projects/pawscore/traces/reqHeader\\",\\"message\\":\\"message\\",\\"data\\":[{\\"a\\":\\"a\\",\\"b\\":\\"b\\"}]}"`;
+
+exports[`Logger should log on equal or higher severity 1`] = `
+Array [
+  Array [
+    "{\\"req\\":{},\\"timestamp\\":\\"2022-01-31T16:00:00.000Z\\",\\"severity\\":\\"ERROR\\",\\"message\\":\\"message\\",\\"data\\":[]}",
+  ],
+  Array [
+    "{\\"req\\":{},\\"timestamp\\":\\"2022-01-31T16:00:00.000Z\\",\\"severity\\":\\"CRITICAL\\",\\"message\\":\\"message\\",\\"data\\":[]}",
+  ],
+]
+`;
+
+exports[`Logger should redact blacklisted fields 1`] = `"{\\"req\\":{},\\"timestamp\\":\\"2022-01-31T16:00:00.000Z\\",\\"severity\\":\\"INFO\\",\\"message\\":\\"message\\",\\"data\\":[{\\"password\\":\\"[Redacted]\\",\\"notPassword\\":\\"123456\\"}]}"`;
+
+exports[`Logger should truncate long strings 1`] = `"{\\"req\\":{},\\"timestamp\\":\\"2022-01-31T16:00:00.000Z\\",\\"severity\\":\\"INFO\\",\\"message\\":\\"message\\",\\"data\\":[{\\"long\\":\\"0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789[...]\\",\\"nested\\":{\\"long\\":\\"0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789[...]\\"},\\"short\\":\\"0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789\\"}]}"`;

--- a/backend/src/helpers/tests/__snapshots__/logger.test.ts.snap
+++ b/backend/src/helpers/tests/__snapshots__/logger.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Logger should extract req information when available 1`] = `"{\\"req\\":{\\"url\\":\\"reqPath\\",\\"id\\":\\"reqId\\"},\\"timestamp\\":\\"2022-01-31T16:00:00.000Z\\",\\"severity\\":\\"INFO\\",\\"logging.googleapis.com/trace\\":\\"projects/pawscore/traces/reqHeader\\",\\"message\\":\\"message\\",\\"data\\":[{\\"a\\":\\"a\\",\\"b\\":\\"b\\"}]}"`;
+exports[`Logger should extract req information when available 1`] = `"{\\"req\\":{\\"url\\":\\"reqPath\\",\\"id\\":\\"reqId\\"},\\"timestamp\\":\\"2022-01-31T16:00:00.000Z\\",\\"severity\\":\\"INFO\\",\\"logging.googleapis.com/trace\\":\\"projects/pawscore/traces/105445aa7843bc8bf206b12000100000\\",\\"message\\":\\"message\\",\\"data\\":[{\\"a\\":\\"a\\",\\"b\\":\\"b\\"}]}"`;
 
 exports[`Logger should log on equal or higher severity 1`] = `
 Array [

--- a/backend/src/helpers/tests/logger.test.ts
+++ b/backend/src/helpers/tests/logger.test.ts
@@ -1,0 +1,144 @@
+import { Request } from "express";
+import { BadRequestError } from "routing-controllers";
+import config from "../../config/config";
+import { Logger, requestContextLocalStorage } from "../logger";
+
+jest.mock("../../config/config", () => ({
+	__esModule: true,
+	default: {
+		nodeEnv: null,
+		logMaxStringLength: 100,
+		logLevel: "debug",
+	},
+}));
+
+const consoleSpy = jest.spyOn(global.console, "log");
+
+describe("Logger", () => {
+	beforeAll(() => {
+		jest.useFakeTimers("modern");
+		jest.setSystemTime(new Date(2022, 1, 1));
+	});
+
+	afterAll(() => {
+		jest.useRealTimers();
+	});
+
+	beforeEach(() => {
+		config.nodeEnv = "";
+		Logger.setLogLevel("debug");
+		jest.clearAllMocks();
+	});
+
+	test("should default to printing single line JSON", () => {
+		Logger.info("message", {
+			a: "a",
+			b: "b",
+		});
+
+		expect(consoleSpy.mock.calls[0][0]).toEqual(
+			`{"req":{},"timestamp":"2022-01-31T16:00:00.000Z","severity":"INFO","message":"message","data":[{"a":"a","b":"b"}]}`,
+		);
+	});
+
+	test("should pretty-print JSON in local environment", () => {
+		config.nodeEnv = "development";
+		Logger.info("message", {
+			a: "a",
+			b: "b",
+		});
+
+		expect(consoleSpy.mock.calls[0][0]).toEqual(
+			`{\n  "req": {},\n  "timestamp": "2022-01-31T16:00:00.000Z",\n  "severity": "INFO",\n  "message": "message",\n  "data": [\n    {\n      "a": "a",\n      "b": "b"\n    }\n  ]\n}`,
+		);
+	});
+
+	test("should log on equal or higher severity", () => {
+		Logger.setLogLevel("error");
+
+		Logger.debug("message");
+		Logger.info("message");
+		Logger.error("message");
+		Logger.fatal("message");
+
+		expect(consoleSpy.mock.calls).toHaveLength(2);
+		expect(consoleSpy.mock.calls).toMatchSnapshot();
+	});
+
+	test("should extract req information when available", () => {
+		const body = {
+			a: "a",
+			b: "b",
+		};
+
+		const context = {
+			id: "reqId",
+			req: {
+				path: "reqPath",
+				header: (name: string) => "reqHeader",
+			} as Request,
+		};
+
+		requestContextLocalStorage.run(context, () => {
+			Logger.info("message", body);
+		});
+
+		expect(consoleSpy.mock.calls[0][0]).toMatchSnapshot();
+	});
+
+	test("should redact blacklisted fields", () => {
+		const body = {
+			password: "abcdef",
+			notPassword: "123456",
+		};
+
+		Logger.info("message", body);
+
+		expect(consoleSpy.mock.calls[0][0]).toMatchSnapshot();
+	});
+
+	test("should truncate long strings", () => {
+		const body = {
+			// 110 chars
+			long: new Array(11)
+				.fill(0)
+				.map(() => "0123456789")
+				.join(""),
+			nested: {
+				long: new Array(11)
+					.fill(0)
+					.map(() => "0123456789")
+					.join(""),
+			},
+			// 100 chars
+			short: new Array(10)
+				.fill(0)
+				.map(() => "0123456789")
+				.join(""),
+		};
+
+		Logger.info("message", body);
+
+		expect(consoleSpy.mock.calls[0][0]).toMatchSnapshot();
+	});
+
+	test("should print error", () => {
+		const error = new Error("error message");
+
+		Logger.info("message", error);
+
+		expect(consoleSpy.mock.calls[0][0]).toEqual(
+			`{"req":{},"timestamp":"2022-01-31T16:00:00.000Z","severity":"INFO","message":"message","data":[{"errorName":"Error","errorMessage":"error message"}]}`,
+		);
+	});
+
+	test("should print routing-controllers error", () => {
+		const error = new BadRequestError("error message");
+
+		Logger.info("message", error);
+
+		expect(consoleSpy.mock.calls[0][0]).toEqual(
+			`{"req":{},"timestamp":"2022-01-31T16:00:00.000Z","severity":"INFO","message":"message","data":[{"errorName":"BadRequestError","errorMessage":"error message"}]}`,
+		);
+	});
+});

--- a/backend/src/helpers/tests/logger.test.ts
+++ b/backend/src/helpers/tests/logger.test.ts
@@ -75,7 +75,11 @@ describe("Logger", () => {
 			id: "reqId",
 			req: {
 				path: "reqPath",
-				header: (name: string) => "reqHeader",
+				header: (name: string) => {
+					return name === "X-Cloud-Trace-Context"
+						? "105445aa7843bc8bf206b12000100000/1;o=1"
+						: "reqHeader";
+				},
 			} as Request,
 		};
 

--- a/backend/src/helpers/tests/logger.test.ts
+++ b/backend/src/helpers/tests/logger.test.ts
@@ -17,7 +17,7 @@ const consoleSpy = jest.spyOn(global.console, "log");
 describe("Logger", () => {
 	beforeAll(() => {
 		jest.useFakeTimers("modern");
-		jest.setSystemTime(new Date(2022, 1, 1));
+		jest.setSystemTime(new Date("2022-01-31T16:00:00.000Z"));
 	});
 
 	afterAll(() => {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -35,10 +35,10 @@ const authRouteSetup = (
 					"local-signup",
 					(error: Error, user: User, info) => {
 						if (error !== null) {
-							console.log(
+							Logger.error(
 								"Error in auth.ts > POST /api/register",
+								error,
 							);
-							console.log(JSON.stringify(error));
 							const result = {
 								status: "failed",
 								message: "Failed to register",
@@ -92,8 +92,10 @@ const authRouteSetup = (
 					"local-login",
 					(err: Error, user: User, info) => {
 						if (err) {
-							console.log("Error in auth.ts > POST /api/login");
-							console.log(JSON.stringify(err));
+							Logger.error(
+								"Error in auth.ts > POST /api/login",
+								err,
+							);
 							return next(err);
 						}
 						if (!user) {

--- a/backend/src/utils/error.ts
+++ b/backend/src/utils/error.ts
@@ -14,12 +14,14 @@ export class ApiErrorMiddleware implements ExpressErrorMiddlewareInterface {
 		request: express.Request,
 		response: express.Response,
 	): void {
-		Logger.log("[ERROR]", error);
 		if (error instanceof HttpError) {
+			Logger.error("Api error", error.message);
 			response.status(error.httpCode).json({ message: error.message });
 		} else if (error instanceof z.ZodError) {
+			Logger.error("Validation error", error.flatten());
 			response.status(400).json({ message: error.message });
 		} else {
+			Logger.error("Unhandled error", error.message);
 			response.status(500).json({ message: "Internal server error" });
 		}
 	}

--- a/backend/src/utils/error.ts
+++ b/backend/src/utils/error.ts
@@ -20,7 +20,7 @@ export class ApiErrorMiddleware implements ExpressErrorMiddlewareInterface {
 			Logger.error("Validation error", error.flatten());
 			response.status(400).json({ message: error.message });
 		} else {
-			Logger.error("Unhandled error", error.message);
+			Logger.error("Unhandled error", error);
 			response.status(500).json({ message: "Internal server error" });
 		}
 	}

--- a/backend/src/utils/error.ts
+++ b/backend/src/utils/error.ts
@@ -1,25 +1,26 @@
 import express from "express";
 import {
-  ExpressErrorMiddlewareInterface,
-  HttpError,
-  Middleware
+	ExpressErrorMiddlewareInterface,
+	HttpError,
+	Middleware,
 } from "routing-controllers";
+import { Logger } from "../helpers/logger";
 import { z } from "zod";
 
 @Middleware({ type: "after" })
 export class ApiErrorMiddleware implements ExpressErrorMiddlewareInterface {
-  error(
-    error: HttpError | Error,
-    request: express.Request,
-    response: express.Response
-  ): void {
-    console.log("[ERROR]", error);
-    if (error instanceof HttpError) {
-      response.status(error.httpCode).json({ message: error.message });
-    } else if (error instanceof z.ZodError) {
-      response.status(400).json({ message: error.message });
-    } else {
-      response.status(500).json({ message: "Internal server error" });
-    }
-  }
+	error(
+		error: HttpError | Error,
+		request: express.Request,
+		response: express.Response,
+	): void {
+		Logger.log("[ERROR]", error);
+		if (error instanceof HttpError) {
+			response.status(error.httpCode).json({ message: error.message });
+		} else if (error instanceof z.ZodError) {
+			response.status(400).json({ message: error.message });
+		} else {
+			response.status(500).json({ message: "Internal server error" });
+		}
+	}
 }

--- a/backend/src/utils/error.ts
+++ b/backend/src/utils/error.ts
@@ -4,7 +4,6 @@ import {
 	HttpError,
 	Middleware,
 } from "routing-controllers";
-import { Logger } from "../helpers/logger";
 import { z } from "zod";
 
 @Middleware({ type: "after" })

--- a/backend/webpack.config.js
+++ b/backend/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack')
 const nodeExternals = require('webpack-node-externals');
 const NodemonPlugin = require('nodemon-webpack-plugin');
 
@@ -32,7 +33,8 @@ module.exports = {
     resolve: {
         extensions: ['.ts', '.js'],
         alias: {
-            "@contract": path.resolve(__dirname, '../contract')
+            "@contract": path.resolve(__dirname, '../contract'),
+            "logger": path.resolve(__dirname, "./src/helpers/logger") 
         }
     },
 
@@ -48,6 +50,9 @@ module.exports = {
     },
 
     plugins: [
+        new webpack.ProvidePlugin({
+            'Logger': ['logger', 'Logger']
+          }),
         new NodemonPlugin({
             nodeArgs: ["--enable-source-maps", "--inspect"]
         })


### PR DESCRIPTION
It'd be good to introduce structured logging so that it's easier to trace logs in production. Each log should minimally identify the originating request (uuid), have a timestamp (Cloud Run seems to append that already), and have a format that is easy to parse/search (JSON?).

This branch is kind of a POC?

- Wanted some thoughts on using AsyncLocalStorage as a way to track the current request context across nested calls without having to explicitly pass down the request object.
- From what I understand, [Cloud Logging will be able to parse serialised JSON](https://cloud.google.com/run/docs/logging#using-json) and extract special fields. I'm using console.dir right now but since it does not output valid JSON, not the best choice here.